### PR TITLE
Fix bug where metac.level results in a 'cannot set property' exception

### DIFF
--- a/lib/winston-riak.js
+++ b/lib/winston-riak.js
@@ -49,6 +49,12 @@ Riak.prototype.log = function (level, msg, meta, callback) {
   var self = this,
       bucketName = this.bucket, 
       metac = winston.clone(meta);
+
+  // Deal with instances where meta (optional) is not passed
+  // such as winston.log('info', 'message');
+  if (metac === null) {
+    metac = {};
+  }
  
   // Deep clone the object for adding to Riak
   metac.level = level;


### PR DESCRIPTION
What I tried:

```
winston.log('info', 'log message')
```

What resulted:

```
/app/node_modules/winston-riak/lib/winston-riak.js:58
  metac.level = level;
              ^
TypeError: Cannot set property 'level' of null
```

`metac` uses `winston.clone` to clone the `meta` parameter, which is optional. When `meta` is null, `metac` is null, and then `metac.level` throws the above error.

This tiny bugfix checks whether `metac` is null or not, and makes it an empty object if null.
