### PR TITLE
Execute log() callback

### DIFF
--- a/lib/winston-riak.js
+++ b/lib/winston-riak.js
@@ -66,10 +66,10 @@ Riak.prototype.log = function (level, msg, meta, callback) {
   this.client.save(bucketName, Date.now(), msg, metac, function (err) {
     if (err) {
       self.emit('error', err);
+      return callback(err, false);
     }
 
+    callback(null, true);
     self.emit('logged');
   });
-
-  callback(null, true);
 };

--- a/lib/winston-riak.js
+++ b/lib/winston-riak.js
@@ -6,7 +6,7 @@
  * MIT LICENCE
  *
  */
- 
+
 var util = require('util'),
     riakjs = require('riak-js'),
     winston = require('winston');
@@ -18,7 +18,7 @@ var util = require('util'),
 var Riak = exports.Riak = function (options) {
  options       = options || {};
  options.debug = options.debug || false;
- 
+
  this.name     = 'riak';
  this.client   = riakjs.getClient(options);
  this.level    = options.level  || 'info';
@@ -32,7 +32,7 @@ var Riak = exports.Riak = function (options) {
 util.inherits(Riak, winston.Transport);
 
 //
-// Define a getter so that `winston.transports.Riak` 
+// Define a getter so that `winston.transports.Riak`
 // is available and thus backwards compatible.
 //
 winston.transports.Riak = Riak;
@@ -47,29 +47,29 @@ winston.transports.Riak = Riak;
 //
 Riak.prototype.log = function (level, msg, meta, callback) {
   var self = this,
-      bucketName = this.bucket, 
+      bucketName = this.bucket,
       metac = winston.clone(meta) || {};
- 
+
   // Deep clone the object for adding to Riak
   metac.level = level;
   metac.contentType = msg instanceof Object ? 'application/json' : 'text/plain';
- 
+
   if (this.generate) {
     var nextBucket = this.bucket(level, msg, meta, Date.now());
     if (this.lastBucket !== nextBucket) {
       this.lastBucket = nextBucket;
     }
-   
+
     bucketName = this.lastBucket;
   }
- 
+
   this.client.save(bucketName, Date.now(), msg, metac, function (err) {
     if (err) {
       self.emit('error', err);
     }
-    
+
     self.emit('logged');
   });
-  
+
   callback(null, true);
 };


### PR DESCRIPTION
Execute the log() callback after the log is saved. Remove some trailing whitespace as well.
